### PR TITLE
ruby 3

### DIFF
--- a/lib/generators/jsonapi/swagger/swagger_generator.rb
+++ b/lib/generators/jsonapi/swagger/swagger_generator.rb
@@ -171,7 +171,7 @@ module Jsonapi
     def tt(key, options={})
       options[:scope] = :jsonapi_swagger
       options[:default] = key.to_s.humanize
-      I18n.t(key, options)
+      I18n.t(key, **options)
     end
 
     def safe_encode(content)


### PR DESCRIPTION
- piggybacking on an old PR
- fix keyword argument problem since we switch to `ruby 3.x`